### PR TITLE
Handle hex-encoded text tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # 112w3
+
+Simple PDF vector renderer experiment.
+
+## Features
+
+- Renders vector shapes to SVG.
+- Supports hex-encoded text tokens such as `<0053> Tj`.
+


### PR DESCRIPTION
## Summary
- Parse `<..>` hex strings during tokenization
- Decode hex text for `Tj`, `TJ`, and `'` operators
- Document hex-encoded text support in README

## Testing
- `node --check text-vector.js`


------
https://chatgpt.com/codex/tasks/task_e_68a217975b5c8324a8efd93bf3b2d157