### PR TITLE
Handle hex-encoded text tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # 112w3
+
+Simple PDF vector renderer experiment.
+
+## Features
+
+- Renders vector shapes to SVG.
+- Supports hex-encoded text tokens such as `<0053> Tj`.
+

--- a/text-vector.js
+++ b/text-vector.js
@@ -191,11 +191,22 @@
         tokens.push({ type: "array", value: arrStr.trim() });
         continue;
       }
+      if (input[i] === '<' && input[i + 1] !== '<') {
+        let hex = "";
+        i++;
+        while (i < input.length && input[i] !== '>') {
+          hex += input[i];
+          i++;
+        }
+        if (i < input.length && input[i] === '>') i++;
+        tokens.push({ type: "hexstring", value: "<" + hex + ">" });
+        continue;
+      }
       let token = "";
       while (i < input.length && !/\s/.test(input[i]) &&
         input[i] !== '(' && input[i] !== '[' && input[i] !== ')') {
         token += input[i];
-      i++;
+        i++;
         }
         if (!isNaN(token)) tokens.push({ type: "number", value: parseFloat(token) });
         else tokens.push({ type: "operator", value: token });
@@ -508,13 +519,15 @@
           }
 
           if (token.type === "operator" && token.value === "Tj") {
-            if (i >= 1 && tokens[i-1].type === "string") {
-              let txt = tokens[i-1].value;
+            if (i >= 1 && (tokens[i-1].type === "string" || tokens[i-1].type === "hexstring")) {
+              let txt = tokens[i-1].type === "hexstring"
+                ? decodeHexString(tokens[i-1].value, fontCache.get(currentFont))
+                : tokens[i-1].value;
               let effective = multiplyMatrix(globalTransform, textTransform);
               let tx = effective[4],
-              ty = effective[5],
-              a = effective[0],
-              b = effective[1];
+                ty = effective[5],
+                a = effective[0],
+                b = effective[1];
               let scale = Math.hypot(a, b) || 1;
               let angleDeg = -Math.atan2(b, a) * 180 / Math.PI;
               let svgY = currentLayer.pdfYToSvgY(ty);
@@ -543,19 +556,23 @@
               let angleDeg = -Math.atan2(b, a) * 180 / Math.PI;
               let svgY = currentLayer.pdfYToSvgY(ty);
               const arrContent = tokens[i-1].value;
-              const regex = /(\([^\)]*(?:\\\)[^\)]*)*\))|([-+]?\d+(\.\d+)?)/g;
+              const regex = /(\([^\)]*(?:\\\)[^\)]*)*\))|(<[^>]+>)|([-+]?\d+(\.\d+)?)/g;
               let match, segments = [];
               let currentDx = 0;
               while ((match = regex.exec(arrContent)) !== null) {
                 if (match[1]) {
                   let txt = match[1].slice(1, -1);
                   txt = txt.replace(/\\\(/g, "(")
-                  .replace(/\\\)/g, ")")
-                  .replace(/\\\\/g, "\\");
+                    .replace(/\\\)/g, ")")
+                    .replace(/\\\\/g, "\\");
                   segments.push({ text: txt, dx: currentDx });
                   currentDx = 0;
                 } else if (match[2]) {
-                  let adjustment = parseFloat(match[2]);
+                  let txt = decodeHexString(match[2], fontCache.get(currentFont));
+                  segments.push({ text: txt, dx: currentDx });
+                  currentDx = 0;
+                } else if (match[3]) {
+                  let adjustment = parseFloat(match[3]);
                   let dxShift = -(adjustment / 1000) * currentFontSize * scale;
                   currentDx += dxShift;
                 }
@@ -592,13 +609,15 @@
           if (token.type === "operator" && token.value === "'") {
             textTransform[4] = initialTextOrigin[0];
             textTransform[5] = initialTextOrigin[1] - currentFontSize;
-            if (i >= 1 && tokens[i-1].type === "string") {
-              let txt = tokens[i-1].value;
+            if (i >= 1 && (tokens[i-1].type === "string" || tokens[i-1].type === "hexstring")) {
+              let txt = tokens[i-1].type === "hexstring"
+                ? decodeHexString(tokens[i-1].value, fontCache.get(currentFont))
+                : tokens[i-1].value;
               let effective = multiplyMatrix(globalTransform, textTransform);
               let tx = effective[4],
-              ty = effective[5],
-              a = effective[0],
-              b = effective[1];
+                ty = effective[5],
+                a = effective[0],
+                b = effective[1];
               let scale = Math.hypot(a, b) || 1;
               let angleDeg = -Math.atan2(b, a) * 180 / Math.PI;
               let svgY = currentLayer.pdfYToSvgY(ty);
@@ -692,18 +711,32 @@
       return '#000'; // fallback
     }
 
-    function renderText(ctx, font, hexStr, x, y, color) {
-      // Convert hex like <0053>
+    function decodeHexString(hexStr, font) {
+      const hex = hexStr.slice(1, -1).replace(/\s+/g, "");
       const bytes = [];
-      for (let i = 1; i < hexStr.length - 1; i += 2)
-        bytes.push(parseInt(hexStr.substr(i,2),16));
-
-      let text = '';
-      for (let b of bytes) {
-        const mapped = font.encodingMap?.[b] || String.fromCharCode(b);
-        text += mapped;
+      for (let i = 0; i < hex.length; i += 2) {
+        const h = hex.substr(i, 2);
+        if (h.length < 2) break;
+        bytes.push(parseInt(h, 16));
       }
+      const encoding = font?.encodingMap || {};
+      const twoByte = bytes.length % 2 === 0 && bytes.some((b, idx) => idx % 2 === 0 && b === 0);
+      let text = '';
+      if (twoByte) {
+        for (let i = 0; i < bytes.length; i += 2) {
+          const code = (bytes[i] << 8) | bytes[i + 1];
+          text += encoding[code] || String.fromCharCode(code);
+        }
+      } else {
+        for (let b of bytes) {
+          text += encoding[b] || String.fromCharCode(b);
+        }
+      }
+      return text;
+    }
 
+    function renderText(ctx, font, hexStr, x, y, color) {
+      const text = decodeHexString(hexStr, font);
       const t = document.createElementNS("http://www.w3.org/2000/svg", "text");
       t.setAttribute("x", x);
       t.setAttribute("y", y);


### PR DESCRIPTION
## Summary
- Parse `<..>` hex strings during tokenization
- Decode hex text for `Tj`, `TJ`, and `'` operators
- Fix hex decoder to support two-byte codes and trim whitespace
- Document hex-encoded text support in README

## Testing
- `node --check text-vector.js`


------
https://chatgpt.com/codex/tasks/task_e_68a217975b5c8324a8efd93bf3b2d157