### PR TITLE
Normalize malformed PDF dictionaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,12 @@ function initPDFExplorer() {
 function extractTopLevelDict(bodyStr) {
   // Normalize malformed brackets and extra closing brackets
   let normalizedStr = bodyStr
-    .replace(/<\s*(\d+\s+\d+\s+R\s*)>>>/g, '<< $1 >>') // Fix < 4 0 R>>> to << 4 0 R >>
-    .replace(/<\s*(\d+\s+\d+\s+R\s*)>>>>/g, '<< $1 >>') // Fix < 4 0 R>>>> to << 4 0 R >>
-    .replace(/<\s*(\[.*?\]\s*)>>/g, '<< $1 >>') // Fix <[2 0 R]>> to << [2 0 R] >>
-    .replace(/\/Font\s*<\s*(\d+\s+\d+\s+R\s*)>>>>/g, '/Font << /F1 $1 >>'); // Fix /Font < 4 0 R>>>> to /Font << /F1 4 0 R >>
+    // Fix cases like < 4 0 R>>> or < 4 0 R>>>>
+    .replace(/<\s*(\d+\s+\d+\s+R\s*)>{2,}/g, '<< $1 >>')
+    // Fix cases like <[2 0 R]>> with array references
+    .replace(/<\s*(\[[^>]*?\]\s*)>{2,}/g, '<< $1 >>')
+    // Fix cases like /Font < 4 0 R>>>>
+    .replace(/\/Font\s*<\s*(\d+\s+\d+\s+R\s*)>{2,}/g, '/Font << /F1 $1 >>');
 
   const start = normalizedStr.indexOf('<<');
   if (start === -1) {


### PR DESCRIPTION
## Summary
- Tolerate extra `>` characters when parsing PDF dictionaries so malformed PDF objects like `<[2 0 R]>>` or `/Font < 4 0 R>>>>` can be opened.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24cbde32083248793977a0bfa42da